### PR TITLE
Fix badge color configuration not being respected

### DIFF
--- a/javascript/background.js
+++ b/javascript/background.js
@@ -125,7 +125,10 @@ chrome.runtime.onStartup.addListener(async () => {
   await setupCleanGoalAlarm()
   await setupContextMenu() // Re-setup context menu on startup too
 
-  // 4. Perform an immediate check to populate the badge correctly
+  // 4. Restore badge color from storage
+  await updateBadgeColor()
+
+  // 5. Perform an immediate check to populate the badge correctly
   await checkSpy()
 })
 


### PR DESCRIPTION
The badge color was defaulting to Chrome's default color on first load after browser restart. This was because the onStartup listener was calling checkSpy() to set the badge text, but never calling updateBadgeColor() to restore the saved badge color from storage.

Added await updateBadgeColor() call before checkSpy() in the onStartup listener to ensure the badge color is restored from storage when the browser starts.

Fixes badge color configuration not being respected after Manifest V3 migration.

Generated with [Claude Code](https://claude.com/claude-code)