### PR TITLE
Remove "tabs" permission

### DIFF
--- a/javascript/background.js
+++ b/javascript/background.js
@@ -196,10 +196,11 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   // Tab updated (e.g., loaded, navigated)
-  // Only update timestamp if status changes to 'complete' for non-chrome URLs,
-  // or if audio state changes (playing/muting).
-  if (changeInfo.status === 'complete' && tab.url && !tab.url.startsWith('chrome://')) {
-    console.log('[Background] Tab updated and loaded:', tabId, tab.url)
+  // Update timestamp when tab finishes loading or audio state changes.
+  // Note: We don't have access to tab.url without "tabs" permission, but we don't need it -
+  // any tab activity (including chrome:// pages) indicates user activity.
+  if (changeInfo.status === 'complete') {
+    console.log('[Background] Tab updated and loaded:', tabId)
     await updateLastActiveTimestamp() // Record activity (debounced)
   } else if (changeInfo.audible !== undefined) {
     console.log('[Background] Tab audio state changed:', tabId)

--- a/manifest.json
+++ b/manifest.json
@@ -22,8 +22,7 @@
     "notifications",
     "contextMenus",
     "alarms",
-    "idle",
-    "tabs"
+    "idle"
   ],
   "host_permissions": [
     "https://api.clicky.com/"


### PR DESCRIPTION
The tabs permission was only needed to access tab.url in the chrome.tabs.onUpdated listener, which we used to filter out chrome:// URLs. However, this check is unnecessary - any tab activity (including internal Chrome pages) indicates user activity for our polling backoff logic.

Changes:
- Removed "tabs" from manifest.json permissions
- Updated chrome.tabs.onUpdated listener to not access tab.url
- Added comment explaining why we don't need the permission

This removes the "Read your browsing history" warning that users see during installation, while maintaining the same functionality for activity-based API polling backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)